### PR TITLE
Feature optimize search multiple file cabinets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 All notable changes to `laravel-docuware` will be documented in this file.
 
+## Unreleased
+
+⚠️ This release introduces breaking changes. Update with caution ⚠️
+
+- **[Breaking Change]**: Searching in multiple file cabinets have been changed.
+  The search no longer supports `additionalFileCabinets()`.  Please use
+  `fileCabinets()` instead. Example:
+
+```php
+$paginator = DocuWare::search()
+    ->fileCabinet('id-first')
+    ->additionalFileCabinets(['id-second'])
+    ->get();
+```
+
+Changed to:
+
+```php
+$paginator = DocuWare::search()
+    ->fileCabinets(['id-first', 'id-second'])
+    ->get();
+```
+
 ## 0.7.0 - 2021-06-30
 
 - Added valid until date for the encrypted URL.

--- a/README.md
+++ b/README.md
@@ -149,17 +149,15 @@ $paginator = DocuWare::search()
     ->get();
 
 /**
- * Search in multiple file cabinets. Provide an array of additional
- * file cabinet ids.
+ * Search in multiple file cabinets. Provide an array of file cabinet ids.
  */
-$ids = [
+$fileCabinetIds = [
     '0ee72de3-4258-4353-8020-6a3ff6dd650f',
     '3f9cb4ff-82f2-44dc-b439-dd648269064f',
 ];
 
 $paginator = DocuWare::search()
-    ->fileCabinet($id)
-    ->additionalFileCabinets($ids)
+    ->fileCabinets($fileCabinetIds)
     ->get();
 
 /**
@@ -239,7 +237,6 @@ $paginator = DocuWare::search()
  */
 $paginator = DocuWare::search()
     ->fileCabinet($id)
-    ->additionalFileCabinets($ids)
     ->page(2)
     ->perPage(30)
     ->fulltext('My secret document')

--- a/src/DocuWareSearch.php
+++ b/src/DocuWareSearch.php
@@ -44,16 +44,18 @@ class DocuWareSearch
         return $this;
     }
 
-    public function dialog(string $dialogId): self
+    public function fileCabinets(array $fileCabinetIds): self
     {
-        $this->dialogId = $dialogId;
+        $this->fileCabinetId = $fileCabinetIds[0] ?? null;
+
+        $this->additionalFileCabinetIds = array_slice($fileCabinetIds, 1);
 
         return $this;
     }
 
-    public function additionalFileCabinets(array $ids): self
+    public function dialog(string $dialogId): self
     {
-        $this->additionalFileCabinetIds = $ids;
+        $this->dialogId = $dialogId;
 
         return $this;
     }

--- a/tests/Feature/DocuWareTest.php
+++ b/tests/Feature/DocuWareTest.php
@@ -227,13 +227,11 @@ class DocuWareTest extends TestCase
     public function it_can_search_documents()
     {
         $fileCabinetId = 'f95f2093-e790-495b-af04-7d198a296c5e';
-        $additionalFileCabinetIds = ['986ee421-9d6b-4a4b-837d-b3e61ea2e681'];
         $dialogId = '6a84f3da-7514-4116-86df-42b56acd19a7';
 
         $paginator = (new DocuWare())
             ->search()
             ->fileCabinet($fileCabinetId)
-            ->additionalFileCabinets($additionalFileCabinetIds)
             ->dialog($dialogId)
             ->page(1)
             ->perPage(5)
@@ -251,11 +249,14 @@ class DocuWareTest extends TestCase
     /** @test */
     public function it_can_search_documents_with_null_values()
     {
-        $fileCabinetId = 'f95f2093-e790-495b-af04-7d198a296c5e';
+        $fileCabinetIds = [
+            'f95f2093-e790-495b-af04-7d198a296c5e',
+            '986ee421-9d6b-4a4b-837d-b3e61ea2e681',
+        ];
 
         $paginator = (new DocuWare())
             ->search()
-            ->fileCabinet($fileCabinetId)
+            ->fileCabinets($fileCabinetIds)
             ->page(null)
             ->perPage(null)
             ->fulltext(null)


### PR DESCRIPTION
Fixes #18 

- **[Breaking Change]**: Searching in multiple file cabinets have been changed.
  The search no longer supports `additionalFileCabinets()`.  Please use
  `fileCabinets()` instead. Example:

```php
$paginator = DocuWare::search()
    ->fileCabinet('id-first')
    ->additionalFileCabinets(['id-second'])
    ->get();
```

Changed to:

```php
$paginator = DocuWare::search()
    ->fileCabinets(['id-first', 'id-second'])
    ->get();
```